### PR TITLE
Remove use of before all and switch to before each

### DIFF
--- a/lib/rspec-steps/describer.rb
+++ b/lib/rspec-steps/describer.rb
@@ -74,15 +74,15 @@ module RSpec::Steps
       #noop
     end
 
-    def before(kind = :all, &callback)
+    def before(kind = :each, &callback)
       @hooks << Hook.new(:before, kind, callback)
     end
 
-    def after(kind = :all, &callback)
+    def after(kind = :each, &callback)
       @hooks << Hook.new(:after, kind, callback)
     end
 
-    def around(kind = :all, &callback)
+    def around(kind = :each, &callback)
       @hooks << Hook.new(:around, kind, callback)
     end
   end

--- a/lib/rspec-steps/step-list.rb
+++ b/lib/rspec-steps/step-list.rb
@@ -79,7 +79,7 @@ module RSpec::Steps
       end ]
 
       step_runner.instance_eval do
-        @step_context.run_after_hooks(:step, @example_runner)
+        @_step_context.run_after_hooks(:step, @_example_runner)
       end
     end
 

--- a/lib/rspec-steps/step-runner.rb
+++ b/lib/rspec-steps/step-runner.rb
@@ -3,13 +3,17 @@ require_relative "step-context"
 module RSpec::Steps
   class StepExampleRunner
     def initialize(context_example, running_example)
-      @context_example = context_example
-      @running_example = running_example
+      @_context_example = context_example
+      @_running_example = running_example
 
-      @current_metadata = {}
-      @let_hash = {}
-      @subject_hash = {}
-      @counter = 0
+      @_current_metadata = {}
+      @_let_hash = {}
+      @_subject_hash = {}
+      @_counter = 0
+
+      context_example.instance_variables.each do |var|
+        instance_variable_set(var, context_example.instance_variable_get(var))
+      end
     end
 
     def should(matcher = nil, message = nil)
@@ -25,73 +29,73 @@ module RSpec::Steps
     end
 
     def metadata
-      @current_metadata
+      @_current_metadata
     end
 
     def method_missing(method, *args, &block)
-      method = @let_hash[method] if @let_hash.key?(method)
-      method = @subject_hash[method] if @subject_hash.key?(method)
-      @context_example.send(method, *args, &block)
+      method = @_let_hash[method] if @_let_hash.key?(method)
+      method = @_subject_hash[method] if @_subject_hash.key?(method)
+      @_context_example.send(method, *args, &block)
     end
 
     def respond_to_missing?(method, include_private = false)
-      method = @let_hash[method] if @let_hash.key?(method)
-      method = @subject_hash[method] if @subject_hash.key?(method)
-      @context_example.respond_to?(method, include_private)
+      method = @_let_hash[method] if @_let_hash.key?(method)
+      method = @_subject_hash[method] if @_subject_hash.key?(method)
+      @_context_example.respond_to?(method, include_private)
     end
   end
 
   class StepRunner
     def initialize(context_example, running_example)
-      @context_example = context_example
-      @running_example = running_example
+      @_context_example = context_example
+      @_running_example = running_example
 
-      @step_context = StepContext.new
-      @metadata_stack = [@running_example.metadata.dup]
-      @example_runner = StepExampleRunner.new(@context_example, @running_example)
+      @_step_context = StepContext.new
+      @_metadata_stack = [@_running_example.metadata.dup]
+      @_example_runner = StepExampleRunner.new(@_context_example, @_running_example)
     end
 
     def before(scope = :step, &block)
-      @step_context.add_before(scope, &block)
+      @_step_context.add_before(scope, &block)
     end
 
     def after(scope = :step, &block)
-      @step_context.add_after(scope, &block)
+      @_step_context.add_after(scope, &block)
     end
 
     def around(scope = :each, &block)
-      @step_context.add_around(scope, &block)
+      @_step_context.add_around(scope, &block)
     end
 
     def describe(description, metadata = {}, &block)
-      @example_runner.instance_eval { @counter += 1 }
+      @_example_runner.instance_eval { @_counter += 1 }
 
-      parent_metadata = @metadata_stack.last.dup
-      @metadata_stack.push(parent_metadata.merge(metadata))
+      parent_metadata = @_metadata_stack.last.dup
+      @_metadata_stack.push(parent_metadata.merge(metadata))
 
       instance_eval(&block)
 
-      @metadata_stack.pop
+      @_metadata_stack.pop
     end
 
     def it(*all_args, &block)
-      @example_runner.instance_variable_set(:@current_metadata, @metadata_stack.last)
+      @_example_runner.instance_variable_set(:@_current_metadata, @_metadata_stack.last)
 
-      @step_context.run_before_hooks(:step, @example_runner)
-      @step_context.run_before_hooks(:each, @example_runner)
+      @_step_context.run_before_hooks(:step, @_example_runner)
+      @_step_context.run_before_hooks(:each, @_example_runner)
 
-      @step_context.run_around_hooks(:each, @example_runner) do
-        @example_runner.instance_eval(&block)
+      @_step_context.run_around_hooks(:each, @_example_runner) do
+        @_example_runner.instance_eval(&block)
       end
 
-      @step_context.run_after_hooks(:each, @example_runner)
+      @_step_context.run_after_hooks(:each, @_example_runner)
     end
 
     def let(name, &block)
-      example_runner = @example_runner
+      example_runner = @_example_runner
       example_runner.instance_eval do
-        @let_hash[name] = "#{name}_#{@counter}"
-        @context_example.class.let("#{name}_#{@counter}") do
+        @_let_hash[name] = "#{name}_#{@_counter}"
+        @_context_example.class.let("#{name}_#{@_counter}") do
           example_runner.instance_eval(&block)
         end
       end
@@ -99,21 +103,21 @@ module RSpec::Steps
 
     def subject(name = nil, &block)
       name = :subject if name.nil?
-      example_runner = @example_runner
+      example_runner = @_example_runner
       example_runner.instance_eval do
-        @subject_hash[name] = "#{name}_#{@counter}"
-        @context_example.class.subject("#{name}_#{@counter}") do
+        @_subject_hash[name] = "#{name}_#{@_counter}"
+        @_context_example.class.subject("#{name}_#{@_counter}") do
           example_runner.instance_eval(&block)
         end
       end
     end
 
     def method_missing(method, *args, &block)
-      @context_example.class.send(method, *args, &block)
+      @_context_example.class.send(method, *args, &block)
     end
 
     def respond_to_missing?(method, include_private = false)
-      @context_example.class.respond_to?(method, include_private)
+      @_context_example.class.respond_to?(method, include_private)
     end
   end
 end

--- a/lib/rspec-steps/step.rb
+++ b/lib/rspec-steps/step.rb
@@ -21,7 +21,7 @@ module RSpec::Steps
       action = self.action
 
       step_runner.instance_eval do
-        instance_exec(@running_example, &action)
+        instance_exec(@_running_example, &action)
       end
     end
 

--- a/spec/example_group_spec.rb
+++ b/spec/example_group_spec.rb
@@ -83,6 +83,34 @@ describe RSpec::Core::ExampleGroup do
       end
     end
 
+    it "should work with before blocks" do
+      group = nil
+      sandboxed do
+        group = RSpec.steps "Top Level Before Block" do
+          before { @a = 10 }
+
+          step "check initial value" do
+            it { expect(@a).to eq(10) }
+          end
+
+          step "increment value" do
+            before { @a += 5 }
+            it { expect(@a).to eq(15) }
+          end
+
+          step "decrement value" do
+            before { @a -= 3 }
+            it { expect(@a).to eq(12) }
+          end
+        end
+        group.run
+      end
+
+      group.examples.each do |example|
+        expect(example.metadata[:execution_result].status).to eq(:passed)
+      end
+    end
+
     it "should work with shared_steps/perform steps" do
       group = nil
       sandboxed do


### PR DESCRIPTION
We probably do not need to use before-all since rspec-steps creates only one it block for all steps - implying before-each block will be called once anyway.

Use of before-each would allow Rails transactional fixtures created inside before block to work out of the box without needing another solution for cleaning the database.

A previous PR also introduced step runner to run steps and that broke access to instance variables. This PR adds test for that behaviour and also fixes the issue by copying the variables from context example to the step runner. Delegation through method missing would not work here.