### PR TITLE
Add support for shared_examples and it_behaves_like inside step runner

### DIFF
--- a/lib/rspec-steps/describer.rb
+++ b/lib/rspec-steps/describer.rb
@@ -46,6 +46,10 @@ module RSpec::Steps
       SharedSteps[name] = Describer.new(args, {:caller => caller}, &block)
     end
 
+    def shared_examples(name, &block)
+      SharedExamples[name] = block
+    end
+
     def include(mod)
       @modules << ModuleInclusion.new(mod)
     end

--- a/lib/rspec-steps/dsl.rb
+++ b/lib/rspec-steps/dsl.rb
@@ -26,10 +26,6 @@ module RSpec::Steps
       raise "there is already a step list named #{name}" if SharedSteps.has_key?(name)
       SharedSteps[name] = Describer.new(*args, {:caller => caller}, &block)
     end
-
-    def shared_example(name, &block)
-      SharedExamples[name] = block
-    end
   end
   extend DSL
 end

--- a/lib/rspec-steps/dsl.rb
+++ b/lib/rspec-steps/dsl.rb
@@ -10,6 +10,7 @@ module RSpec::Steps
   end
 
   SharedSteps = {}
+  SharedExamples = {}
 
   module DSL
     def steps(*args, &block)
@@ -24,6 +25,10 @@ module RSpec::Steps
       raise "shared step lists need a String for a name" unless name.is_a? String
       raise "there is already a step list named #{name}" if SharedSteps.has_key?(name)
       SharedSteps[name] = Describer.new(*args, {:caller => caller}, &block)
+    end
+
+    def shared_example(name, &block)
+      SharedExamples[name] = block
     end
   end
   extend DSL

--- a/lib/rspec-steps/step-runner.rb
+++ b/lib/rspec-steps/step-runner.rb
@@ -108,6 +108,12 @@ module RSpec::Steps
       end
     end
 
+    def it_behaves_like(name, *args)
+      describe(name) do
+        instance_exec(*args, &SharedExamples[name])
+      end
+    end
+
     def method_missing(method, *args, &block)
       @context_example.class.send(method, *args, &block)
     end

--- a/spec/example_group_spec.rb
+++ b/spec/example_group_spec.rb
@@ -106,6 +106,36 @@ describe RSpec::Core::ExampleGroup do
       end
     end
 
+    it "should work with shared_examples" do
+      group = nil
+      sandboxed do
+        group = RSpec.steps "Test Steps" do
+          shared_examples "common behavior" do |value|
+            it("adds shared value") { values << value }
+          end
+
+          let(:values) { [] }
+
+          step "adds first value" do
+            it_behaves_like "common behavior", "first"
+          end
+
+          step "adds second value" do
+            it_behaves_like "common behavior", "second"
+          end
+
+          step "check values" do
+            it { expect(values).to eq(["first", "second"]) }
+          end
+        end
+        group.run
+      end
+
+      group.examples.each do |example|
+        expect(example.metadata[:execution_result].status).to eq(:passed)
+      end
+    end
+
     it "should be able to access an example in blocks" do
       group = nil
       metadata = nil


### PR DESCRIPTION
Adds support for `shared_examples` and `it_behaves_like` inside step block.

This is implemented by treating a shared_example block as just another describe block inside step block. `shared_examples` are stored globally similar to `shared_steps` and then fetched and executed inside a describe block.