### PR TITLE
Add block arguments support to shared_steps

### DIFF
--- a/lib/rspec-steps/describer.rb
+++ b/lib/rspec-steps/describer.rb
@@ -43,7 +43,7 @@ module RSpec::Steps
       name = args.first
       raise "shared step lists need a String for a name" unless name.is_a? String
       raise "there is already a step list named #{name}" if SharedSteps.has_key?(name)
-      SharedSteps[name] = Describer.new(args, {:caller => caller}, &block)
+      SharedSteps[name] = block
     end
 
     def shared_examples(name, &block)
@@ -58,12 +58,10 @@ module RSpec::Steps
       @modules << ModuleExtension.new(mod)
     end
 
-    def perform_steps(name)
-      describer = SharedSteps.fetch(name)
-      @modules += describer.modules
-      @let_list += describer.let_list
-      @hooks += describer.hooks
-      @step_list += describer.step_list
+    def perform_steps(name, *args)
+      block = SharedSteps.fetch(name)
+      # Execute the shared steps block directly in the current context
+      instance_exec(*args, &block)
     end
 
     def let(name, &block)

--- a/lib/rspec-steps/dsl.rb
+++ b/lib/rspec-steps/dsl.rb
@@ -24,7 +24,7 @@ module RSpec::Steps
       name = args.first
       raise "shared step lists need a String for a name" unless name.is_a? String
       raise "there is already a step list named #{name}" if SharedSteps.has_key?(name)
-      SharedSteps[name] = Describer.new(*args, {:caller => caller}, &block)
+      SharedSteps[name] = block
     end
   end
   extend DSL

--- a/spec/example_group_spec.rb
+++ b/spec/example_group_spec.rb
@@ -106,6 +106,30 @@ describe RSpec::Core::ExampleGroup do
       end
     end
 
+    it "should work with shared_steps with block arguments" do
+      group = nil
+      sandboxed do
+        group = RSpec.steps "Test Steps" do
+          shared_steps "add value" do |value|
+            it("adds #{value} to @values") { @values << value }
+          end
+
+          it("initialize values array") { @values = [] }
+          perform_steps "add value", "first"
+          perform_steps "add value", "second"
+          perform_steps "add value", "third"
+          it("check values") { @values.should == ["first", "second", "third"] }
+        end
+        group.run
+      end
+
+      expect(group.examples.length).to eq(5)
+
+      group.examples.each do |example|
+        expect(example.metadata[:execution_result].status).to eq(:passed)
+      end
+    end
+
     it "should work with shared_examples" do
       group = nil
       sandboxed do


### PR DESCRIPTION
This PR enhances the `shared_steps` functionality to support block arguments, making shared step definitions more flexible and reusable by allowing parameterization.

## Benefits

1. **Increased Reusability**: Shared steps can now be parameterized, reducing code duplication
2. **Dynamic Step Generation**: Steps can be generated with dynamic descriptions and behavior based on arguments
3. **Simplified Architecture**: Removed complexity of maintaining separate Describer instances for shared steps
4. **Backward Compatibility**: Existing shared_steps without arguments continue to work unchanged

## Example Usage

```ruby
shared_steps "add value" do |value|
  it("adds #{value} to @values") { @values << value }
end

# Usage
perform_steps "add value", "first"
perform_steps "add value", "second"
```

## Testing

- Added test case `"should work with shared_steps with block arguments"` 
- Test verifies that parameterized shared steps execute correctly and maintain proper state
- All existing tests continue to pass, ensuring backward compatibility